### PR TITLE
Fix formatting and linting.

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+test/locale-data.ts

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ node_js:
   - node
 
 script:
-  - npm run test
+  - npm run test:ci
 
 after_success:
   - npm run report-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
-
 node_js:
   - "6"
   - "8"
@@ -15,9 +14,6 @@ cache:
 
 notifications:
   email: false
-
-node_js:
-  - node
 
 script:
   - npm run test:ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: node_js
 
+node_js:
+  - "6"
+  - "8"
+  - "10"
+
 branches:
   only:
     - master

--- a/package.json
+++ b/package.json
@@ -10,11 +10,12 @@
     "build": "tsc && tsc --outDir dist/es && rollup -c rollup.config.ts",
     "lint": "tslint -t codeFrame 'src/**/*.ts' 'test/format.test.ts'",
     "prepare": "npm run build",
-    "prepublishOnly": "npm test && npm run lint",
+    "prepublishOnly": "npm run test:ci",
     "preversion": "npm run lint",
     "start": "tsc -w & rollup -c rollup.config.ts -w",
     "prebuild": "rimraf dist",
-    "test": "jest"
+    "test": "jest",
+    "test:ci": "npm test && npm run lint"
   },
   "jest": {
     "transform": {

--- a/src/format-utils.ts
+++ b/src/format-utils.ts
@@ -5,6 +5,10 @@ export function replaceNumber(normalized: any, format: string): string {
   return format.replace(/0*/, normalized);
 }
 
+export function polishString(str: string): string {
+  return str.replace("'.'", '.');
+}
+
 export function normalizeLocale(locale: string | string[]): string {
   if (locale instanceof Array) {
     return locale[0].replace(/_/, '-').toLowerCase();

--- a/src/format.ts
+++ b/src/format.ts
@@ -2,6 +2,7 @@ import {
   findLocaleData,
   needsFormatting,
   normalizeLocale,
+  polishString,
   replaceNumber
 } from './format-utils';
 import { extractIntPart, normalizeNumber } from './math-utils';
@@ -87,5 +88,5 @@ export function compactFormat(
     options
   );
 
-  return replaceNumber(normalized, formatter);
+  return polishString(replaceNumber(normalized, formatter));
 }

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -1,9 +1,9 @@
 import compactFormat from '../src';
 import { compactFormat as format } from '../src/format';
-import { en, es } from './locale-data';
+import { en, es, fi } from './locale-data';
 
 // due to regex replacement
-function replaceWhitespace(val: any) {
+function normalizeWhitespace(val: any) {
   return val.replace(/\s+/, ' ');
 }
 
@@ -35,29 +35,29 @@ describe('format number', () => {
   it('returns value if localeData provided', () => {
     const localeData = es;
     let result = format(1234, 'es', localeData);
-    expect(replaceWhitespace(result)).toBe('1 mil');
+    expect(normalizeWhitespace(result)).toBe('1 mil');
     result = format(11234, 'es', localeData);
-    expect(replaceWhitespace(result)).toBe('11 mil');
+    expect(normalizeWhitespace(result)).toBe('11 mil');
     result = format(94999, 'es', localeData);
-    expect(replaceWhitespace(result)).toBe('95 mil');
+    expect(normalizeWhitespace(result)).toBe('95 mil');
     result = format(95000, 'es', localeData);
-    expect(replaceWhitespace(result)).toBe('95 mil');
+    expect(normalizeWhitespace(result)).toBe('95 mil');
     result = format(95001, 'es', localeData);
-    expect(replaceWhitespace(result)).toBe('100 mil');
+    expect(normalizeWhitespace(result)).toBe('100 mil');
     result = format(100000, 'es', localeData);
-    expect(replaceWhitespace(result)).toBe('100 mil');
+    expect(normalizeWhitespace(result)).toBe('100 mil');
   });
 
   it('returns value if threshold provided', () => {
     const localeData = es;
     let result = format(1234, 'es', localeData, { threshold: 0.1 });
-    expect(replaceWhitespace(result)).toBe('1 mil');
+    expect(normalizeWhitespace(result)).toBe('1 mil');
     result = format(11234, 'es', localeData, { threshold: 0.1 });
-    expect(replaceWhitespace(result)).toBe('11 mil');
+    expect(normalizeWhitespace(result)).toBe('11 mil');
     result = format(89999, 'es', localeData, { threshold: 0.1 });
-    expect(replaceWhitespace(result)).toBe('90 mil');
+    expect(normalizeWhitespace(result)).toBe('90 mil');
     result = format(90001, 'es', localeData, { threshold: 0.1 });
-    expect(replaceWhitespace(result)).toBe('90 mil');
+    expect(normalizeWhitespace(result)).toBe('90 mil');
     // result = format(95001, 'es', localeData, { threshold: 0.1 });
     // expect(replaceWhitespace(result)).toBe('100 mil');
   });
@@ -67,15 +67,15 @@ describe('format number', () => {
     let result = format(1234, 'es', localeData, {
       significantDigits: 1
     });
-    expect(replaceWhitespace(result)).toBe('1.2 mil');
+    expect(normalizeWhitespace(result)).toBe('1.2 mil');
     result = format(11234, 'es', localeData, {
       significantDigits: 1
     });
-    expect(replaceWhitespace(result)).toBe('11.2 mil');
+    expect(normalizeWhitespace(result)).toBe('11.2 mil');
     result = format(91934, 'es', localeData, {
       significantDigits: 2
     });
-    expect(replaceWhitespace(result)).toBe('91.93 mil');
+    expect(normalizeWhitespace(result)).toBe('91.93 mil');
   });
 
   it('returns with financial format', () => {
@@ -84,11 +84,20 @@ describe('format number', () => {
       financialFormat: true,
       significantDigits: 1
     });
-    expect(replaceWhitespace(result)).toBe('1.2K');
+    expect(normalizeWhitespace(result)).toBe('1.2K');
     result = format(101000, 'en', localeData, {
       financialFormat: true,
       significantDigits: 1
     });
-    expect(replaceWhitespace(result)).toBe('0.1M');
+    expect(normalizeWhitespace(result)).toBe('0.1M');
+  });
+
+  it("replaces `'.'` in the formatting string with just a .", () => {
+    const localeData = fi;
+    const result = format(1234, 'fi', localeData, {
+      significantDigits: 1
+    });
+
+    expect(normalizeWhitespace(result)).toBe('1.2 t.');
   });
 });

--- a/test/locale-data.ts
+++ b/test/locale-data.ts
@@ -29,3 +29,19 @@ export const en = {
     }
   }
 }
+
+export const fi = {
+  fi: {
+    "locale": "fi",
+    "numbers": {
+      "decimal": {
+        "long": [
+          [1000, { "one": ["0 tuhat", 1], "other": ["0 tuhatta", 1] }], [10000, { "one": ["00 tuhatta", 2], "other": ["00 tuhatta", 2] }], [100000, { "one": ["000 tuhatta", 3], "other": ["000 tuhatta", 3] }], [1000000, { "one": ["0 miljoona", 1], "other": ["0 miljoonaa", 1] }], [10000000, { "one": ["00 miljoonaa", 2], "other": ["00 miljoonaa", 2] }], [100000000, { "one": ["000 miljoonaa", 3], "other": ["000 miljoonaa", 3] }], [1000000000, { "one": ["0 miljardi", 1], "other": ["0 miljardia", 1] }], [10000000000, { "one": ["00 miljardia", 2], "other": ["00 miljardia", 2] }], [100000000000, { "one": ["000 miljardia", 3], "other": ["000 miljardia", 3] }], [1000000000000, { "one": ["0 biljoona", 1], "other": ["0 biljoonaa", 1] }], [10000000000000, { "one": ["00 biljoonaa", 2], "other": ["00 biljoonaa", 2] }], [100000000000000, { "one": ["000 biljoonaa", 3], "other": ["000 biljoonaa", 3] }]
+        ],
+        "short": [
+          [1000, { "one": ["0 t'.'", 1], "other": ["0 t'.'", 1] }], [10000, { "one": ["00 t'.'", 2], "other": ["00 t'.'", 2] }], [100000, { "one": ["000 t'.'", 3], "other": ["000 t'.'", 3] }], [1000000, { "one": ["0 milj'.'", 1], "other": ["0 milj'.'", 1] }], [10000000, { "one": ["00 milj'.'", 2], "other": ["00 milj'.'", 2] }], [100000000, { "one": ["000 milj'.'", 3], "other": ["000 milj'.'", 3] }], [1000000000, { "one": ["0 mrd'.'", 1], "other": ["0 mrd'.'", 1] }], [10000000000, { "one": ["00 mrd'.'", 2], "other": ["00 mrd'.'", 2] }], [100000000000, { "one": ["000 mrd'.'", 3], "other": ["000 mrd'.'", 3] }], [1000000000000, { "one": ["0 bilj'.'", 1], "other": ["0 bilj'.'", 1] }], [10000000000000, { "one": ["00 bilj'.'", 2], "other": ["00 bilj'.'", 2] }], [100000000000000, { "one": ["000 bilj'.'", 3], "other": ["000 bilj'.'", 3] }]
+        ]
+      }
+    }
+  }
+};

--- a/tslint.json
+++ b/tslint.json
@@ -7,7 +7,7 @@
   ],
   "linterOptions": {
     "exclude": [
-      "tests/locale-data.ts"
+      "test/locale-data.ts"
     ]
   },
   "jsRules": {},


### PR DESCRIPTION
In first place, let me apologize for too many changes in one PR. I needed to fix the Finnish formatting
but linting got into my editor's way so this is the complete list of
changes:

- Fix formatting for a few languages. Some languages include a dot in
the short format and in the data we get that dot surrounded by single
quotes. This is the main reason for this PR.
- Make the project pass its linting rules.
- Make CI check linting.
- Fix path in tslint.json to properly exclude test/locale-data.ts
- Add test/locale-data.ts to .prettierignore
- Fix the versions of Node being used in Travis to prevent https://github.com/facebook/create-react-app/issues/6591 (though it is a create-react-app issue it is related to Jest not working on Node 11.11.0)